### PR TITLE
AbstractAreaクラスを継承

### DIFF
--- a/InfoArea.pde
+++ b/InfoArea.pde
@@ -1,0 +1,12 @@
+class InfoArea extends AbstractArea {
+  InfoArea(int posX, int posY, int yoko, int tate) {
+    super(posX, posY, yoko, tate);
+  }
+  void draw() {
+    fill(#FFFFFF);
+    rect(posX*SQUARESIZE, posY*SQUARESIZE, yoko*SQUARESIZE, tate*SQUARESIZE);
+    fill(#000000);
+    textSize(20);
+    text("<- Left turn", (posX+0.3)*SQUARESIZE, (posY+0.5)*SQUARESIZE);
+  }
+}


### PR DESCRIPTION
親クラス（AbstractAreaクラス）で定義されたエリアの左上座標(poX, posY)と縦幅(tate)，横幅(yoko)を初期化する．